### PR TITLE
Add rgb565/bgr565 pixel formats

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
 					<select id="pixfmtInput">
 						<option value="rgb">RGB</option>
 						<option value="bgr">BGR</option>
+						<option value="rgb565">RGB565</option>
+						<option value="rgb565be">RGB565BE</option>
+						<option value="bgr565">BGR565</option>
+						<option value="bgr565be">BGR565BE</option>
 						<option value="rgba">RGBA</option>
 						<option value="bgra">BGRA</option>
 						<option value="argb">ARGB</option>

--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
 					<select id="pixfmtInput">
 						<option value="rgb">RGB</option>
 						<option value="bgr">BGR</option>
-						<option value="rgb565">RGB565</option>
+						<option value="rgb565le">RGB565LE</option>
 						<option value="rgb565be">RGB565BE</option>
-						<option value="bgr565">BGR565</option>
+						<option value="bgr565le">BGR565LE</option>
 						<option value="bgr565be">BGR565BE</option>
 						<option value="rgba">RGBA</option>
 						<option value="bgra">BGRA</option>

--- a/pixfmt.js
+++ b/pixfmt.js
@@ -130,7 +130,7 @@ let pixfmts = {
 		convert: (dest, src, soffset, width, height) =>
 			convertRGB(dest, src, soffset, width, height, 2, 1, 0),
 	},
-	rgb565: {
+	rgb565le: {
 		bpp: 2,
 		convert: (dest, src, soffset, width, height) =>
 			convertRGB565(dest, src, soffset, width, height, 0, 1, 2, false),
@@ -140,7 +140,7 @@ let pixfmts = {
 		convert: (dest, src, soffset, width, height) =>
 			convertRGB565(dest, src, soffset, width, height, 0, 1, 2, true),
 	},
-	bgr565: {
+	bgr565le: {
 		bpp: 2,
 		convert: (dest, src, soffset, width, height) =>
 			convertRGB565(dest, src, soffset, width, height, 2, 1, 0, false),

--- a/pixfmt.js
+++ b/pixfmt.js
@@ -22,6 +22,28 @@ function convertRGBA(dest, src, soffset, width, height, r, g, b, a) {
 	}
 }
 
+function convertRGB565(dest, src, soffset, width, height, r, g, b, big_endian) {
+    let srci = soffset;
+    let desti = 0;
+    for (let i = 0; i < width * height; ++i) {
+		let pixel = (
+			big_endian ?
+				(src[srci] << 8) | src[srci+1] 
+				:(src[srci+1] << 8) | src[srci]
+		);
+		let third = 0x1f & pixel;
+		let second = 0x3f & (pixel >> 5);
+		let first = 0x1f & (pixel >> (5+6));
+
+        let pixels = [Math.round( first * 255.0 / 31.0), Math.round( second * 255.0 / 63.0), Math.round( third * 255.0 / 31.0)];
+        dest[desti++] = pixels[r];
+        dest[desti++] = pixels[g];
+        dest[desti++] = pixels[b];
+        dest[desti++] = 255;
+        srci += 2;
+    }
+}
+
 function convertGreyscale(dest, src, soffset, width, height) {
 	let srci = soffset;
 	let desti = 0;
@@ -107,6 +129,26 @@ let pixfmts = {
 		bpp: 3,
 		convert: (dest, src, soffset, width, height) =>
 			convertRGB(dest, src, soffset, width, height, 2, 1, 0),
+	},
+	rgb565: {
+		bpp: 2,
+		convert: (dest, src, soffset, width, height) =>
+			convertRGB565(dest, src, soffset, width, height, 0, 1, 2, false),
+	},
+	rgb565be: {
+		bpp: 2,
+		convert: (dest, src, soffset, width, height) =>
+			convertRGB565(dest, src, soffset, width, height, 0, 1, 2, true),
+	},
+	bgr565: {
+		bpp: 2,
+		convert: (dest, src, soffset, width, height) =>
+			convertRGB565(dest, src, soffset, width, height, 2, 1, 0, false),
+	},
+	bgr565be: {
+		bpp: 2,
+		convert: (dest, src, soffset, width, height) =>
+			convertRGB565(dest, src, soffset, width, height, 2, 1, 0, true),
 	},
 	rgba: {
 		bpp: 4,

--- a/test-images/Makefile
+++ b/test-images/Makefile
@@ -1,6 +1,6 @@
 FFMPEG = ffmpeg -loglevel warning
 
-FORMATS = rgb bgr rgba bgra argb abgr nv12 nv21 yuyv yvyu i420
+FORMATS = rgb bgr rgba bgra argb abgr nv12 nv21 yuyv yvyu i420 rgb565 rgb565be bgr565 bgr565be
 IMAGES = \
 	$(patsubst %,peppers_267x267.%,$(FORMATS)) \
 	$(patsubst %,tulips_768x512.%,$(FORMATS)) \
@@ -63,6 +63,26 @@ all: $(IMAGES)
 	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt yuv420p $@
 %.i420: %.png
 	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt yuv420p $@
+
+%.rgb565: %.jpg
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565 $@
+%.rgb565: %.png
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565 $@
+
+%.rgb565be: %.jpg
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565be $@
+%.rgb565be: %.png
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565be $@
+
+%.bgr565: %.jpg
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565 $@
+%.bgr565: %.png
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565 $@
+
+%.bgr565be: %.jpg
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565be $@
+%.bgr565be: %.png
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565be $@
 
 .PHONY: clean
 clean:

--- a/test-images/Makefile
+++ b/test-images/Makefile
@@ -1,6 +1,6 @@
 FFMPEG = ffmpeg -loglevel warning
 
-FORMATS = rgb bgr rgba bgra argb abgr nv12 nv21 yuyv yvyu i420 rgb565 rgb565be bgr565 bgr565be
+FORMATS = rgb bgr rgba bgra argb abgr nv12 nv21 yuyv yvyu i420 rgb565le rgb565be bgr565le bgr565be
 IMAGES = \
 	$(patsubst %,peppers_267x267.%,$(FORMATS)) \
 	$(patsubst %,tulips_768x512.%,$(FORMATS)) \
@@ -64,20 +64,20 @@ all: $(IMAGES)
 %.i420: %.png
 	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt yuv420p $@
 
-%.rgb565: %.jpg
-	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565 $@
-%.rgb565: %.png
-	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565 $@
+%.rgb565le: %.jpg
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565le $@
+%.rgb565le: %.png
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565le $@
 
 %.rgb565be: %.jpg
 	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565be $@
 %.rgb565be: %.png
 	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt rgb565be $@
 
-%.bgr565: %.jpg
-	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565 $@
-%.bgr565: %.png
-	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565 $@
+%.bgr565le: %.jpg
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565le $@
+%.bgr565le: %.png
+	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565le $@
 
 %.bgr565be: %.jpg
 	$(FFMPEG) -y -i $< -f rawvideo -pix_fmt bgr565be $@


### PR DESCRIPTION
RGB565/BGR565 pixel format LCD screens are used pretty commonly with arduino and other cheap microcontrollers.
It's also fairly common for embedded systems to just use pre-converted raw formats for storing images.

Also: thanks for writing this tool, i miss rawpixels.net :cry: 